### PR TITLE
removing tags from log message

### DIFF
--- a/movai_core_shared/logger.py
+++ b/movai_core_shared/logger.py
@@ -299,9 +299,8 @@ class LogAdapter(logging.LoggerAdapter):
         """
         raw_tags = dict(kwargs)
         raw_tags.update(self._tags)
-        tags = "|".join([f"{k}:{v}" for k, v in raw_tags.items()])
         kwargs = {"extra": {"tags": raw_tags}}
-        return f"[{tags}] {msg}", kwargs
+        return f"{msg}", kwargs
 
 
 class LogsQuery:


### PR DESCRIPTION
[BP-957](https://movai.atlassian.net/browse/BP-957) - Logs message have unnecessary details such as tags values

[BP-957]: https://movai.atlassian.net/browse/BP-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ