### PR TITLE
return traceback on LogAdapter and added default tag for user tags

### DIFF
--- a/movai_core_shared/consts.py
+++ b/movai_core_shared/consts.py
@@ -12,6 +12,7 @@ from os import getpid
 PID = getpid()
 
 # Constants
+USER_LOG_TAG = "user_log"
 MAX_LOG_QUERY = 1000000
 MIN_LOG_QUERY = 0
 DEFAULT_LOG_LIMIT = 1000

--- a/movai_core_shared/core/zmq_client.py
+++ b/movai_core_shared/core/zmq_client.py
@@ -36,7 +36,6 @@ class ZMQClient:
         self._socket.setsockopt(zmq.IDENTITY, self._identity)
         self._socket.setsockopt(zmq.SNDTIMEO, int(MOVAI_ZMQ_TIMEOUT_MS))
         self._socket.connect(server)
-        self._logger.info(f"successfully connected to {server}")
 
     def __del__(self):
         """closes the socket when the object is destroyed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 100

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,52 @@
+import logging
+from movai_core_shared.logger import Log, LogAdapter
+from movai_core_shared.exceptions import MovaiException
+
+
+def check_log(caplog, expected):
+    """help function to validate the log"""
+    assert caplog.text == expected
+    caplog.clear()
+
+
+def check_trackback(caplog, should_have_trackback):
+    """help function to validate the log"""
+    if should_have_trackback:
+        assert "Traceback" in caplog.text
+    else:
+        assert "Traceback" not in caplog.text
+    caplog.clear()
+
+
+def test_logger(caplog):
+    """Test for the logger that will generate new logger with get_logger
+    and test out all the different verbosity and check the logs that are correct
+    """
+    caplog.set_level(logging.DEBUG, logger="test_logger")
+    log = Log.get_logger("test_logger")
+    log.addHandler(caplog.handler)
+    logger = LogAdapter(log)
+    try:
+        log.info("in try log")
+        check_log(caplog, "INFO     test_logger:test_logger.py:30 in try log\n")
+        logger.error("in try logger")
+        check_log(caplog, "ERROR    test_logger:test_logger.py:32 [user_log:True] in try logger\n")
+        log.debug("a %s 2 %f 3 %i" % ("a", 2, 3))
+        check_log(caplog, "DEBUG    test_logger:test_logger.py:34 a a 2 2.000000 3 3\n")
+        msg = "message"
+        logger.warning(f"this is a {msg}")
+        check_log(caplog, "WARNING  test_logger:test_logger.py:37 [user_log:True] this is a message\n")
+        raise MovaiException("test error")
+    except MovaiException as e:
+        logger.error("test error logger", e)
+        check_trackback(caplog, True)
+        logger.warning(f"test error 2 logger e:{e}")
+        check_trackback(caplog, False)
+        log.error(f"test log error e:{e}")
+        check_trackback(caplog, False)
+        logger.info("test logger info e:{e}")
+        check_trackback(caplog, False)
+        logger.critical("last")
+        breakpoint()
+        check_trackback(caplog, True)
+    assert True

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -47,6 +47,5 @@ def test_logger(caplog):
         logger.info("test logger info e:{e}")
         check_trackback(caplog, False)
         logger.critical("last")
-        breakpoint()
         check_trackback(caplog, True)
     assert True


### PR DESCRIPTION
 - [BP-995](https://movai.atlassian.net/browse/BP-995): missing logs information
      -  the lost feature that prints tracelog on error print that happens after an exception also changed it print only LogAdapter only been used by users
 - [BP-1019](https://movai.atlassian.net/browse/BP-1019): New spam log
      - Removed spam line 
 - [BP-1019](https://movai.atlassian.net/browse/BP-988): Logs not displayed 

[BP-995]: https://movai.atlassian.net/browse/BP-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BP-1019]: https://movai.atlassian.net/browse/BP-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ