### PR TITLE
BP-982 used term instead of destroy

### DIFF
--- a/movai_core_shared/core/zmq_client.py
+++ b/movai_core_shared/core/zmq_client.py
@@ -41,7 +41,8 @@ class ZMQClient:
         """closes the socket when the object is destroyed.
         """
         # Close all sockets associated with this context and then terminate the context.
-        self.zmq_ctx.destroy()
+        self._socket.close()
+        self.zmq_ctx.term()
 
     def send(self, msg: dict) -> None:
         """


### PR DESCRIPTION
- [BP-982](https://movai.atlassian.net/browse/BP-982): Spawner dies and restarts when running a flow
    - backend dies because of destroy (not thread safe), need to close socket and call term instead.
      changes tested and working fine with api_tests

[BP-982]: https://movai.atlassian.net/browse/BP-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ