### PR TITLE
Version 2.4.1.14 BugFixes

### DIFF
--- a/movai_core_shared/core/zmq_client.py
+++ b/movai_core_shared/core/zmq_client.py
@@ -31,8 +31,8 @@ class ZMQClient:
         """
         self._logger = getLogger(self.__class__.__name__)
         self._identity = identity.encode("utf-8")
-        zmq_ctx = zmq.Context()
-        self._socket = zmq_ctx.socket(zmq.DEALER)
+        self.zmq_ctx = zmq.Context()
+        self._socket = self.zmq_ctx.socket(zmq.DEALER)
         self._socket.setsockopt(zmq.IDENTITY, self._identity)
         self._socket.setsockopt(zmq.SNDTIMEO, int(MOVAI_ZMQ_TIMEOUT_MS))
         self._socket.connect(server)
@@ -40,7 +40,8 @@ class ZMQClient:
     def __del__(self):
         """closes the socket when the object is destroyed.
         """
-        self._socket.close()
+        # Close all sockets associated with this context and then terminate the context.
+        self.zmq_ctx.destroy()
 
     def send(self, msg: dict) -> None:
         """

--- a/movai_core_shared/logger.py
+++ b/movai_core_shared/logger.py
@@ -29,6 +29,7 @@ from movai_core_shared.consts import (
     SYSLOG_MEASUREMENT,
     SYSLOGS_HANDLER_MSG_TYPE,
     PID,
+    USER_LOG_TAG,
 )
 from movai_core_shared.envvars import (
     DEVICE_NAME,
@@ -149,7 +150,7 @@ class RemoteHandler(logging.StreamHandler):
             record.msg = str(record.msg)
 
         log_tags = {"robot": DEVICE_NAME, "level": record.levelname, "service": SERVICE_NAME}
-        
+
         syslog_tags = {
             "appname": SERVICE_NAME,
             "facility": "console",
@@ -161,7 +162,6 @@ class RemoteHandler(logging.StreamHandler):
         if hasattr(record, "tags"):
             log_tags.update(record.tags)
             syslog_tags.update(record.tags)
-        
 
         log_fields = {
             "module": record.module,
@@ -245,40 +245,6 @@ def get_remote_handler(log_level=logging.NOTSET):
     return remote_handler
 
 
-class Log:
-    """
-    A static class to help create logger instances
-    """
-
-    LOG_FILE = "movai.log"
-
-    @staticmethod
-    def set_log_file(name: str):
-        """
-        Set the name of the file we write the log
-        """
-        Log.LOG_FILE = name
-
-    @staticmethod
-    def get_logger(logger_name: str):
-        """
-        Get a logger instance
-        """
-        logger = logging.getLogger(logger_name)
-        if logger.hasHandlers():
-            logger.handlers = []
-        if MOVAI_STDOUT_VERBOSITY_LEVEL != logging.NOTSET:
-            logger.addHandler(_get_console_handler())
-        if MOVAI_LOGFILE_VERBOSITY_LEVEL != logging.NOTSET:
-            logger.addHandler(_get_file_handler())
-        if is_enteprise():
-            if MOVAI_FLEET_LOGS_VERBOSITY_LEVEL != logging.NOTSET:
-                logger.addHandler(get_remote_handler())
-        logger.setLevel(MOVAI_GENERAL_VERBOSITY_LEVEL)
-        logger.propagate = False
-        return logger
-
-
 class LogAdapter(logging.LoggerAdapter):
     """
     A LogAdapter used to expose the logger inside a callback, we should
@@ -339,6 +305,69 @@ class LogAdapter(logging.LoggerAdapter):
         tags = "|".join([f"{k}:{v}" for k, v in raw_tags.items()])
         kwargs = {"extra": {"tags": raw_tags}}
         return f"[{tags}] {msg}", kwargs
+
+
+class Log:
+    """
+    A static class to help create logger instances
+    """
+
+    LOG_FILE = "movai.log"
+
+    @staticmethod
+    def set_log_file(name: str):
+        """
+        Set the name of the file we write the log
+        """
+        Log.LOG_FILE = name
+
+    @staticmethod
+    def get_logger(logger_name: str):
+        """
+        Get a logger instance
+        """
+        logger = logging.getLogger(logger_name)
+        if logger.hasHandlers():
+            logger.handlers = []
+        if MOVAI_STDOUT_VERBOSITY_LEVEL != logging.NOTSET:
+            logger.addHandler(_get_console_handler())
+        if MOVAI_LOGFILE_VERBOSITY_LEVEL != logging.NOTSET:
+            logger.addHandler(_get_file_handler())
+        if is_enteprise():
+            if MOVAI_FLEET_LOGS_VERBOSITY_LEVEL != logging.NOTSET:
+                logger.addHandler(get_remote_handler())
+        logger.setLevel(MOVAI_GENERAL_VERBOSITY_LEVEL)
+        logger.propagate = False
+        return logger
+
+    @classmethod
+    def get_user_logger(cls, logger_name: str, **tags: dict) -> LogAdapter:
+        """Add 'user_log=True' tag to the logger.
+
+        Args:
+            logger_name (str): The name of the logger.
+
+        Returns:
+            LogAdapter: A logger with tags.
+        """
+        tags[USER_LOG_TAG] = True
+        user_logger = LogAdapter(cls.get_logger(logger_name), **tags)
+        return user_logger
+
+    @classmethod
+    def get_callback_logger(
+        cls, logger_name: str, node_name: str, callback_name: str
+    ) -> LogAdapter:
+        """Adds 'user_log=True', 'node' and 'callback' tags to the logger.
+
+        Args:
+            logger_name (str): The name of the logger.
+
+        Returns:
+            LogAdapter: A logger with tags.
+        """
+        logger = cls.get_user_logger(logger_name, node=node_name, callback=callback_name)
+        return logger
 
 
 class LogsQuery:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -30,12 +30,12 @@ def test_logger(caplog):
         log.info("in try log")
         check_log(caplog, "INFO     test_logger:test_logger.py:30 in try log\n")
         logger.error("in try logger")
-        check_log(caplog, "ERROR    test_logger:test_logger.py:32 [user_log:True] in try logger\n")
+        check_log(caplog, "ERROR    test_logger:test_logger.py:32 [] in try logger\n")
         log.debug("a %s 2 %f 3 %i" % ("a", 2, 3))
         check_log(caplog, "DEBUG    test_logger:test_logger.py:34 a a 2 2.000000 3 3\n")
         msg = "message"
         logger.warning(f"this is a {msg}")
-        check_log(caplog, "WARNING  test_logger:test_logger.py:37 [user_log:True] this is a message\n")
+        check_log(caplog, "WARNING  test_logger:test_logger.py:37 [] this is a message\n")
         raise MovaiException("test error")
     except MovaiException as e:
         logger.error("test error logger", e)


### PR DESCRIPTION
- [BP-982](https://movai.atlassian.net/browse/BP-982): Spawner dies and restarts when running a flow
    - backend dies because of destroy (not thread safe), need to close socket and call term instead.
      changes tested and working fine with api_tests
- [BP-1025](https://movai.atlassian.net/browse/BP-1025) - logs from spawner are not displayed

[BP-982]: https://movai.atlassian.net/browse/BP-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BP-1025]: https://movai.atlassian.net/browse/BP-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ