### PR TITLE
reduce the timeout for force kill to 7 sec

### DIFF
--- a/movai_core_shared/consts.py
+++ b/movai_core_shared/consts.py
@@ -101,7 +101,7 @@ NAME_REGEX = r"^(\/)?[~@a-zA-Z_0-9-.]+([~@a-zA-Z_0-9-]+)?([\/a-zA-Z_0-9-.]+)?$"
 LINK_REGEX = r"^([~@a-zA-Z_0-9-]+)([\/])([\/~@a-zA-Z_0-9]+)+([\/])([~@a-zA-Z_0-9]+)$"
 CONFIG_REGEX = r"\$\((param|config|var|flow)[^$)]+\)"
 
-TIMEOUT_PROCESS_SIGINT = 15
+TIMEOUT_PROCESS_SIGINT = 7
 TIMEOUT_PROCESS_SIGTERM = 2
 
 # Domains


### PR DESCRIPTION
see this PR need to be together 
or it can cause problems
https://github.com/MOV-AI/flow-initiator/pull/102

from there:
- changed the timeout to 7 seconds until force kill, helps with fast transition and can reduce the problem with a node that refuses to die
- Unload the flow first thing, that will make sure that no transition can happen when the flow is stopped
- Lock outside the try block, and update the lock with a loop, that causes a deprecation warning
- increased the catch to catch any type of exception, for better stability for the spawner