### PR TITLE
BP-1096: add tags to the logs (#120)

### DIFF
--- a/movai_core_shared/logger.py
+++ b/movai_core_shared/logger.py
@@ -314,8 +314,11 @@ class LogAdapter(logging.LoggerAdapter):
         """
         raw_tags = dict(kwargs)
         raw_tags.update(self._tags)
+        tags = "|".join([f"{k}:{v}" for k, v in raw_tags.items()])
         kwargs = {"extra": {"tags": raw_tags}}
-        return f"{msg}", kwargs
+
+        return f"[{tags}] {msg}", kwargs
+ 
 
 
 class Log:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -30,12 +30,12 @@ def test_logger(caplog):
         log.info("in try log")
         check_log(caplog, "INFO     test_logger:test_logger.py:30 in try log\n")
         logger.error("in try logger")
-        check_log(caplog, "ERROR    test_logger:test_logger.py:32 in try logger\n")
+        check_log(caplog, "ERROR    test_logger:test_logger.py:32 [] in try logger\n")
         log.debug("a %s 2 %f 3 %i" % ("a", 2, 3))
         check_log(caplog, "DEBUG    test_logger:test_logger.py:34 a a 2 2.000000 3 3\n")
         msg = "message"
         logger.warning(f"this is a {msg}")
-        check_log(caplog, "WARNING  test_logger:test_logger.py:37 this is a message\n")
+        check_log(caplog, "WARNING  test_logger:test_logger.py:37 [] this is a message\n")
         raise MovaiException("test error")
     except MovaiException as e:
         logger.error("test error logger", e)


### PR DESCRIPTION
- [BP-1096](https://movai.atlassian.net/browse/BP-1096): Robot card shows full UI log instead of just text
  - readding the tags to logs, the fix is needed in message-server and not here

[BP-1096]: https://movai.atlassian.net/browse/BP-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ