### PR TITLE
Add consts for context issue fix

### DIFF
--- a/movai_core_shared/consts.py
+++ b/movai_core_shared/consts.py
@@ -40,8 +40,10 @@ NODE_TYPE = [
 ]
 
 MOVAI_INIT = "MovAI/Init"
+MOVAI_TRANSITION = "MovAI/Transition"
 MOVAI_TRANSITIONFOR = "MovAI/TransitionFor"
 MOVAI_TRANSITIONTO = "MovAI/TransitionTo"
+MOVAI_CONTEXTCLIENTIN = "MovAI/ContextClientIn"
 MOVAI_DEPENDS = "MovAI/Depends"
 MOVAI_DEPENDENCY = "MovAI/Dependency"
 


### PR DESCRIPTION
- Add **_context client in_** and _**transition**_ constants. These were needed for identification of a context related iport, and the moment of a node intialization
