### PR TITLE
Update timeout values for killing nodes

### DIFF
--- a/movai_core_shared/consts.py
+++ b/movai_core_shared/consts.py
@@ -104,8 +104,8 @@ NAME_REGEX = r"^(\/)?[~@a-zA-Z_0-9-.]+([~@a-zA-Z_0-9-]+)?([\/a-zA-Z_0-9-.]+)?$"
 LINK_REGEX = r"^([~@a-zA-Z_0-9-]+)([\/])([\/~@a-zA-Z_0-9]+)+([\/])([~@a-zA-Z_0-9]+)$"
 CONFIG_REGEX = r"\$\((param|config|var|flow)[^$)]+\)"
 
-TIMEOUT_PROCESS_SIGINT = 7
-TIMEOUT_PROCESS_SIGTERM = 2
+TIMEOUT_PROCESS_SIGINT = 3  # seconds
+TIMEOUT_PROCESS_SIGTERM = 2  # seconds
 
 # Domains
 INTERNAL_DOMAIN = "internal"


### PR DESCRIPTION
Continuation from https://github.com/MOV-AI/flow-initiator/pull/157

TIcket: [BP-1253](https://movai.atlassian.net/browse/BP-1253)

- timeout of termination were changed:
  - TIMEOUT_PROCESS_SIGTERM = 2  # seconds, unchanged but now used rightfully to consider the SIGTERM was not efficient
  - TIMEOUT_PROCESS_SIGINT = 3  # seconds  (formerly 7), now used rightfully to consider the SIGINT was not efficient which will lead to a SIGKILL

[BP-1253]: https://movai.atlassian.net/browse/BP-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ