### PR TITLE
BP-1330: Add variable to control waiting for a ZMQ response

### DIFF
--- a/movai_core_shared/consts.py
+++ b/movai_core_shared/consts.py
@@ -106,6 +106,7 @@ CONFIG_REGEX = r"\$\((param|config|var|flow)[^$)]+\)"
 
 TIMEOUT_PROCESS_SIGINT = 3  # seconds
 TIMEOUT_PROCESS_SIGTERM = 2  # seconds
+TIMEOUT_SEND_CMD_RESPONSE = 10  # seconds
 
 # Domains
 INTERNAL_DOMAIN = "internal"


### PR DESCRIPTION
Ticket: [BP-1330](https://movai.atlassian.net/browse/BP-1330)

Used by https://github.com/MOV-AI/data-access-layer/pull/267


- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes



[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1330]: https://movai.atlassian.net/browse/BP-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ