### PR TITLE
BP-1370 fix callback logging

### DIFF
--- a/movai_core_shared/logger.py
+++ b/movai_core_shared/logger.py
@@ -308,11 +308,11 @@ class LogAdapter(logging.LoggerAdapter):
 
     def error(self, *args, **kwargs):
         new_msg, kwargs = self.get_message(*args, **kwargs)
-        self.logger.error(new_msg, stacklevel=2, **kwargs)
+        self.logger.error(new_msg, stacklevel=3, **kwargs)
 
     def critical(self, *args, **kwargs):
         new_msg, kwargs = self.get_message(*args, **kwargs)
-        self.logger.critical(new_msg, stacklevel=2, **kwargs)
+        self.logger.critical(new_msg, stacklevel=3, **kwargs)
 
     def process(self, msg, kwargs):
         """


### PR DESCRIPTION
Since we have that redirection on error and critical, they require another stack level. Thats why it was increased to 3.

Before the fix

![image](https://github.com/user-attachments/assets/3267c157-2e48-49ad-87b7-c68954fa73f7)


After fix:

![image](https://github.com/user-attachments/assets/45aa87c5-e5b4-418d-9b78-06b56633a8c1)
