### PR TITLE
Add add_shared_handler_to_root

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Welcome to movai-core-shared's documentation!
 
    readme
    modules
+   logging
 
 .. include:: readme.rst
 

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -1,0 +1,10 @@
+Logging
+=======
+
+Tools executed outside entrypoint
+---------------------------------
+
+The logs of processes / tools executed outside the entrypoint do not show in docker logs by default.
+In order to improve debugging we forward them to docker logs by configuring the
+`DETACHED_PROCESS_OUTPUT` environment variable and by setup a handler in the root logger with
+`add_shared_handler_to_root`.

--- a/movai_core_shared/__init__.py
+++ b/movai_core_shared/__init__.py
@@ -6,6 +6,8 @@
    Developers:
    - Dor Marcous (Dor@mov.ai) - 2022
 """
+__version__ = "3.1.0.2"
+
 # pylint: skip-file
 from movai_core_shared.consts import (
     ROS1_NODELET,

--- a/movai_core_shared/common/utils.py
+++ b/movai_core_shared/common/utils.py
@@ -11,7 +11,6 @@
 """
 import asyncio
 import socket
-from pkg_resources import get_distribution
 from movai_core_shared.envvars import REDIS_MASTER_HOST
 
 
@@ -61,18 +60,6 @@ def get_ip_address() -> str:
     hostname = socket.gethostname()
     ip_addr = socket.gethostbyname(hostname)
     return ip_addr
-
-
-def get_package_version(package_name: str) -> str:
-    """Gets the verison of a package
-
-    Args:
-        package_name (str): The package to extract the version
-
-    Returns:
-        str: The version of the package.
-    """
-    return get_distribution(package_name).version
 
 
 async def run_blocking_code(executor, blocking_func, *args):

--- a/movai_core_shared/envvars.py
+++ b/movai_core_shared/envvars.py
@@ -1,4 +1,10 @@
-""" Compilation of necessary environment variables to push to the database """
+"""Environment variables.
+
+Attributes:
+    DETACHED_PROCESS_OUTPUT (str): Where to forward logs from e.g. tools that
+        run outside the entrypoint.
+
+"""
 import os
 from logging import DEBUG, getLevelName
 import socket
@@ -29,6 +35,7 @@ MOVAI_CALLBACK_VERBOSITY_LEVEL = getLevelName(
 )  # Verbosity level for callback logs
 LOG_HTTP_HOST = os.environ.get("LOG_HTTP_HOST", "http://health-node:8081")
 MOVAI_IPC_PATH = os.getenv("MOVAI_IPC_PATH", "/opt/mov.ai/comm")
+DETACHED_PROCESS_OUTPUT = os.getenv("DETACHED_PROCESS_OUTPUT")
 
 # Read variables from current environment
 APP_PATH = os.getenv("APP_PATH")

--- a/movai_core_shared/logger.py
+++ b/movai_core_shared/logger.py
@@ -16,7 +16,6 @@ from datetime import datetime
 import logging
 from logging.handlers import TimedRotatingFileHandler
 import syslog
-from pathlib import Path
 
 from movai_core_shared.common.utils import get_package_version
 from movai_core_shared.common.time import current_timestamp_int
@@ -49,6 +48,7 @@ from movai_core_shared.envvars import (
     MASTER_MESSAGE_SERVER,
     SERVICE_NAME,
     SYSLOG_ENABLED,
+    DETACHED_PROCESS_OUTPUT,
 )
 from movai_core_shared.core.message_client import MessageClient, AsyncMessageClient
 from movai_core_shared.common.utils import is_enterprise, is_manager
@@ -58,8 +58,6 @@ from movai_core_shared.log_handlers.callback_handler import (
     CallbackLogAdapter,
 )
 from movai_core_shared.log_handlers.generic_handler import LogAdapter
-
-SHARED_LOGS = Path("/tmp/shared-log")
 
 LOG_FORMATTER_DATETIME = "%Y-%m-%d %H:%M:%S"
 S_FORMATTER = (
@@ -278,7 +276,7 @@ def get_remote_handler(log_level=logging.NOTSET):
 
 def add_shared_handler_to_root():
     """Add handler to root so logs can be tailed and redirected to e.g. docker logs."""
-    handler = logging.FileHandler(SHARED_LOGS)
+    handler = logging.FileHandler(DETACHED_PROCESS_OUTPUT)
     handler.setFormatter(logging.Formatter(LOG_FORMATTER_EXPR))
     root = logging.getLogger()
     root.addHandler(handler)

--- a/movai_core_shared/logger.py
+++ b/movai_core_shared/logger.py
@@ -5,10 +5,6 @@ Proprietary and confidential
 Developers:
 - Dor Marcous (dor@mov.ai) - 2022
 
-Attributes:
-    SHARED_LOGS (Path): Shared logs FIFO, expected to be created in
-        service entrypoint.
-
 """
 import asyncio
 import sys
@@ -17,7 +13,7 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 import syslog
 
-from movai_core_shared.common.utils import get_package_version
+from movai_core_shared import __version__ as VERSION
 from movai_core_shared.common.time import current_timestamp_int
 
 from movai_core_shared.consts import (
@@ -79,7 +75,6 @@ SEVERETY_CODES_MAPPING = {
     "DEBUG": syslog.LOG_DEBUG,
 }
 
-VERSION = get_package_version("movai-core-shared")
 logging.getLogger("rosout").setLevel(MOVAI_CALLBACK_VERBOSITY_LEVEL)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ replace = 'version = "{new_version}"'
 regex = true
 
 [[tool.bumpversion.files]]
+filename = "movai_core_shared/__init__.py"
+search = '__version__ = "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"'
+replace = '__version__ = "{new_version}"'
+regex = true
+
+[[tool.bumpversion.files]]
 filename = "CHANGELOG.md"
 search = '# vTBD'
 serialize = ["{major}.{minor}.{patch}"]


### PR DESCRIPTION
- [BP-1381](https://movai.atlassian.net/browse/BP-1381): User creation logs are not present in backend logs making hard to debug
  - `propagate` must be true so root handlers are propagated to child loggers
  - remove usage of `get_distribution` which breaks dev environment (from time to time) and docs

[BP-1381]: https://movai.atlassian.net/browse/BP-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ