### PR TITLE
DP-1798: Fix Docker exception when using quickstart

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "beartype==0.14.1",
     "cryptography==2.8",
-    "requests==2.32.3",
+    "requests<2.32.0",
     "pyzmq==26.0.0",
     "pydantic[email]==2.5.2",
 ]


### PR DESCRIPTION
- Freeze requests version as dependency of package under 2.32, in order to fix the following startup error:
```
[CRITICAL][2025-05-15 13:45:46][ttdocker_client][__init__][80]: Can't reach docker daemon: DockerException: Error while fetching server API version: Not supported URL scheme http+docker
```